### PR TITLE
NPJ 112 - Adição do Enum MedidaJuridica

### DIFF
--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/Ficha.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/Ficha.java
@@ -3,6 +3,7 @@ package com.uniprojecao.fabrica.gprojuridico.domains.atendimento;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.uniprojecao.fabrica.gprojuridico.domains.Endereco;
+import com.uniprojecao.fabrica.gprojuridico.domains.MedidaJuridica;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,13 +20,23 @@ import java.util.List;
 })
 public abstract class Ficha {
     private String assinatura;
+    private String medidaJuridica;
     private Boolean dadosSensiveis;
     private List<Testemunha> testemunhas = new ArrayList<>();
 
-    public Ficha(String assinatura, Boolean dadosSensiveis, List<Testemunha> testemunhas) {
+    public Ficha(String assinatura, String medidaJuridica, Boolean dadosSensiveis, List<Testemunha> testemunhas) {
         this.assinatura = assinatura;
         this.dadosSensiveis = dadosSensiveis;
+        setMedidaJuridica(medidaJuridica);
         setTestemunhas(testemunhas);
+    }
+
+    public void setMedidaJuridica(String medidaJuridica) {
+        this.medidaJuridica = MedidaJuridica.valueOf(medidaJuridica
+                .replace(" – ", " ") // substitui travessão
+                .replace(" - ", " ") // substitui hífen
+                .replace(" ", "_")
+                .toUpperCase()).getNormalizedValue();
     }
 
     public void setTestemunhas(List<Testemunha> testemunhas) {

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/FichaCivil.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/FichaCivil.java
@@ -9,11 +9,9 @@ import java.util.List;
 @NoArgsConstructor
 public class FichaCivil extends Ficha {
     private ParteContraria parteContraria;
-    private String medidaJudicial;
 
-    public FichaCivil(String assinatura, Boolean dadosSensiveis, List<Testemunha> testemunhas, ParteContraria parteContraria, String medidaJudicial) {
-        super(assinatura, dadosSensiveis, testemunhas);
+    public FichaCivil(String assinatura, Boolean dadosSensiveis, List<Testemunha> testemunhas, ParteContraria parteContraria, String medidaJuridica) {
+        super(assinatura, medidaJuridica, dadosSensiveis, testemunhas);
         this.parteContraria = parteContraria;
-        this.medidaJudicial = medidaJudicial;
     }
 }

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/FichaTrabalhista.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/domains/atendimento/FichaTrabalhista.java
@@ -13,8 +13,8 @@ public class FichaTrabalhista extends Ficha {
     private DocumentosDepositadosNpj documentosDepositadosNpj;
     private String outrasInformacoes;
 
-    public FichaTrabalhista(String assinatura, Boolean dadosSensiveis, List<Testemunha> testemunhas, Reclamado reclamado, RelacaoEmpregaticia relacaoEmpregaticia, DocumentosDepositadosNpj documentosDepositadosNpj, String outrasInformacoes) {
-        super(assinatura, dadosSensiveis, testemunhas);
+    public FichaTrabalhista(String assinatura, Boolean dadosSensiveis, String medidaJuridica, List<Testemunha> testemunhas, Reclamado reclamado, RelacaoEmpregaticia relacaoEmpregaticia, DocumentosDepositadosNpj documentosDepositadosNpj, String outrasInformacoes) {
+        super(assinatura, medidaJuridica, dadosSensiveis, testemunhas);
         this.reclamado = reclamado;
         this.relacaoEmpregaticia = relacaoEmpregaticia;
         this.documentosDepositadosNpj = documentosDepositadosNpj;

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaCivilDTO.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaCivilDTO.java
@@ -12,9 +12,9 @@ public class FichaCivilDTO extends FichaDTO {
     private ParteContraria parteContraria;
     private String medidaJudicial;
 
-    public FichaCivilDTO(String assinatura, Boolean dadosSensiveis, List<TestemunhaDTO> testemunhasDTO, ParteContraria parteContraria, String medidaJudicial) {
-        super(assinatura, dadosSensiveis, testemunhasDTO);
+    public FichaCivilDTO(String assinatura, Boolean dadosSensiveis, List<TestemunhaDTO> testemunhasDTO, ParteContraria parteContraria, String medidaJuridica) {
+        super(assinatura, medidaJuridica, dadosSensiveis, testemunhasDTO);
         this.parteContraria = parteContraria;
-        this.medidaJudicial = medidaJudicial;
+        this.medidaJudicial = medidaJuridica;
     }
 }

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaDTO.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaDTO.java
@@ -2,7 +2,7 @@ package com.uniprojecao.fabrica.gprojuridico.dto.atendimento;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.uniprojecao.fabrica.gprojuridico.domains.Endereco;
+import com.uniprojecao.fabrica.gprojuridico.domains.MedidaJuridica;
 import com.uniprojecao.fabrica.gprojuridico.dto.EnderecoDTO;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Data
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
@@ -23,7 +22,23 @@ import java.util.List;
 public abstract class FichaDTO {
     private String assinatura;
     private Boolean dadosSensiveis;
+    private String medidaJuridica;
     private List<TestemunhaDTO> testemunhas = new ArrayList<>();
+
+    public FichaDTO(String assinatura, String medidaJuridica, Boolean dadosSensiveis, List<TestemunhaDTO> testemunhas) {
+        this.assinatura = assinatura;
+        this.dadosSensiveis = dadosSensiveis;
+        setMedidaJuridica(medidaJuridica);
+        setTestemunhas(testemunhas);
+    }
+
+    public void setMedidaJuridica(String medidaJuridica) {
+        this.medidaJuridica = MedidaJuridica.valueOf(medidaJuridica
+                .replace(" – ", " ") // substitui travessão
+                .replace(" - ", " ") // substitui hífen
+                .replace(" ", "_")
+                .toUpperCase()).getNormalizedValue();
+    }
 
     public void setTestemunhas(List<TestemunhaDTO> testemunhas) {
         this.testemunhas.addAll(testemunhas);

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaTrabalhistaDTO.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/dto/atendimento/FichaTrabalhistaDTO.java
@@ -18,8 +18,8 @@ public class FichaTrabalhistaDTO extends FichaDTO {
     private DocumentosDepositadosNpj documentosDepositadosNpj;
     private String outrasInformacoes;
 
-    public FichaTrabalhistaDTO(String assinatura, Boolean dadosSensiveis, List<TestemunhaDTO> testemunhasDTO, Reclamado reclamado, RelacaoEmpregaticia relacaoEmpregaticia, DocumentosDepositadosNpj documentosDepositadosNpj, String outrasInformacoes) {
-        super(assinatura, dadosSensiveis, testemunhasDTO);
+    public FichaTrabalhistaDTO(String assinatura, Boolean dadosSensiveis, String medidaJuridica, List<TestemunhaDTO> testemunhasDTO, Reclamado reclamado, RelacaoEmpregaticia relacaoEmpregaticia, DocumentosDepositadosNpj documentosDepositadosNpj, String outrasInformacoes) {
+        super(assinatura, medidaJuridica, dadosSensiveis, testemunhasDTO);
         this.reclamado = reclamado;
         this.relacaoEmpregaticia = relacaoEmpregaticia;
         this.documentosDepositadosNpj = documentosDepositadosNpj;

--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/services/utils/AtendimentoUtils.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/services/utils/AtendimentoUtils.java
@@ -100,6 +100,7 @@ public class AtendimentoUtils {
                     new FichaTrabalhista(
                             dto.getFicha().getAssinatura(),
                             dto.getFicha().getDadosSensiveis(),
+                            dto.getFicha().getMedidaJuridica(),
                             dto.getFicha().getTestemunhas()
                                     .stream()
                                     .map(t -> new Ficha.Testemunha(
@@ -162,7 +163,7 @@ public class AtendimentoUtils {
                                             )
                                     ).toList(),
                             ficha.getParteContraria(),
-                            ficha.getMedidaJudicial()
+                            ficha.getMedidaJuridica()
                     )
             );
         }
@@ -198,7 +199,7 @@ public class AtendimentoUtils {
                             t.getEndereco().getCidade()
                     )))
                     .toList();
-            at.setFicha(new FichaTrabalhistaDTO(f.getAssinatura(), f.getDadosSensiveis(), testemunhasDTO, f.getReclamado(), f.getRelacaoEmpregaticia(), f.getDocumentosDepositadosNpj(), f.getOutrasInformacoes()));
+            at.setFicha(new FichaTrabalhistaDTO(f.getAssinatura(), f.getDadosSensiveis(), f.getMedidaJuridica(), testemunhasDTO, f.getReclamado(), f.getRelacaoEmpregaticia(), f.getDocumentosDepositadosNpj(), f.getOutrasInformacoes()));
 
             return at;
         } else {
@@ -229,7 +230,7 @@ public class AtendimentoUtils {
                             t.getEndereco().getCidade()
                     )))
                             .toList();
-            ac.setFicha(new FichaCivilDTO(f.getAssinatura(), f.getDadosSensiveis(), testemunhasDTO, f.getParteContraria(), f.getMedidaJudicial()));
+            ac.setFicha(new FichaCivilDTO(f.getAssinatura(), f.getDadosSensiveis(), testemunhasDTO, f.getParteContraria(), f.getMedidaJuridica()));
 
             return ac;
         }

--- a/src/test/java/com/uniprojecao/fabrica/gprojuridico/aggregators/AtendimentoAggregator.java
+++ b/src/test/java/com/uniprojecao/fabrica/gprojuridico/aggregators/AtendimentoAggregator.java
@@ -128,7 +128,7 @@ public class AtendimentoAggregator implements ArgumentsAggregator {
             var relacaoEmpregaticia = new RelacaoEmpregaticia();
             var docDepositadosNpj= new DocumentosDepositadosNpj();
 
-            var ficha = new FichaTrabalhista(null, false, new ArrayList<>(), reclamado, relacaoEmpregaticia, docDepositadosNpj, null);
+            var ficha = new FichaTrabalhista(null, false, "Reclamação trabalhista", new ArrayList<>(), reclamado, relacaoEmpregaticia, docDepositadosNpj, null);
             at.setFicha(ficha);
 
             return at;

--- a/src/test/java/com/uniprojecao/fabrica/gprojuridico/data/AtendimentoData.java
+++ b/src/test/java/com/uniprojecao/fabrica/gprojuridico/data/AtendimentoData.java
@@ -32,7 +32,7 @@ public class AtendimentoData {
         var reclamado = new Reclamado();
         var relacaoEmpregaticia = new RelacaoEmpregaticia();
         var docDepositadosNpj= new DocumentosDepositadosNpj();
-        var fichaTrabalhista = new FichaTrabalhista(null, false, new ArrayList<>(), reclamado, relacaoEmpregaticia, docDepositadosNpj, null);
+        var fichaTrabalhista = new FichaTrabalhista(null, false, "Reclamação trabalhista", new ArrayList<>(), reclamado, relacaoEmpregaticia, docDepositadosNpj, null);
 
         return List.of(
                 new AtendimentoCivil("ATE00052", "Processo ativo", "Civil", null, historico, envolvidos, fichaCivil),


### PR DESCRIPTION
Conforme repassado pela coordenadora Luciana, o atributo "medidaJudicial" presente na classe `FichaCivil` foi alterado para suportar opção finitas de medidas jurídicas cabíveis em um atendimento que ocorrer no estabelecimento.

Agora a classe `Ficha` apresente este atributo a qual é herdado nas classes filhas, como `FichaCivil` e `FichaTrabalhista`.

## Teste Manual (e Isolada) de Implementação Realizada

![Enum MedidaJuridica funcional](https://github.com/fabuniprojecaotag/npj-backend/assets/72327035/9bad60c4-8b4f-40f4-aa3c-fe69d9a65d49)
