### PR TITLE
NPJ 86 - Correção do método update() em UsuarioService

### DIFF
--- a/src/main/java/com/uniprojecao/fabrica/gprojuridico/services/BaseService.java
+++ b/src/main/java/com/uniprojecao/fabrica/gprojuridico/services/BaseService.java
@@ -1,7 +1,6 @@
 package com.uniprojecao.fabrica.gprojuridico.services;
 
 import com.uniprojecao.fabrica.gprojuridico.repository.BaseRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Map;
 
@@ -25,7 +24,7 @@ public class BaseService {
     }
 
     public void deleteAll(String limit, String field, String filter, String value) {
-        BaseRepository.deleteAll(collectionName, null, parseInt(limit), initFilter(field, filter, value)); // TODO: Converter método para static
+        BaseRepository.deleteAll(collectionName, null, parseInt(limit), initFilter(field, filter, value));
     }
 
 

--- a/src/test/java/com/uniprojecao/fabrica/gprojuridico/services/UsuarioServiceTest.java
+++ b/src/test/java/com/uniprojecao/fabrica/gprojuridico/services/UsuarioServiceTest.java
@@ -98,13 +98,27 @@ class UsuarioServiceTest {
         @Order(3)
         void update() {
             var id = "leticia.alves";
+            var rawPassword = "132435";
 
-            var originalEmail = service.findById(id).getEmail();
-            service.update(id, Map.of("email", "letici.alves@projecao.br"));
+            var user = service.findById(id);
+            service.update(id, Map.of(
+                    "nome", "Letícia Neves",
+                    "email", "letica.neves@projecao.br",
+                    "senha", rawPassword
+            ));
             sleep(1000); // Evita que o findById() pegue o valor antigo
-            var updatedEmail = service.findById(id).getEmail();
+            var updatedUser = service.findById(id);
+            var encryptedPassword = updatedUser.getSenha();
 
-            assertNotEquals(originalEmail, updatedEmail, "User shoud not have the same e-mail");
+            System.out.println("original: " + user);
+            System.out.println("updated: " + updatedUser);
+
+            assertAll(
+                    () -> assertNotEquals(user, updatedUser, "User shoud not have the same data"),
+                    () -> assertNotEquals(rawPassword, encryptedPassword, "User shoud have the password encrypted")
+            );
+
+
         }
 
         @ParameterizedTest


### PR DESCRIPTION
Com esta PR, o método update() na classe "UsuarioService" foi atualizado para evitar que quando o atributo "senha" esteja presente, este seja armazenado no banco de dados sem o devido tratamento de criptografia.